### PR TITLE
Add setting option for 12H clock mode by default 12H mode displays A…

### DIFF
--- a/core/src/main/java/com/m3u/core/architecture/preferences/Preferences.kt
+++ b/core/src/main/java/com/m3u/core/architecture/preferences/Preferences.kt
@@ -83,6 +83,8 @@ class Preferences @Inject constructor(
     sharedPreferences.booleanAsState(DEFAULT_ALWAYS_TV, ALWAYS_TV)
     var remoteControl: Boolean by
     sharedPreferences.booleanAsState(DEFAULT_REMOTE_CONTROL, REMOTE_CONTROL)
+    var twelveHourClock: Boolean by
+    sharedPreferences.booleanAsState(DEFAULT_12_H_CLOCK_MODE, CLOCK_MODE)
     var progress: Boolean by
     sharedPreferences.booleanAsState(DEFAULT_PROGRESS, PROGRESS)
     var alwaysShowReplay: Boolean by
@@ -138,6 +140,8 @@ class Preferences @Inject constructor(
         const val DEFAULT_CACHE = false
         const val DEFAULT_RANDOMLY_IN_FAVOURITE = false
 
+        const val DEFAULT_12_H_CLOCK_MODE = false
+
         const val PLAYLIST_STRATEGY = "playlist-strategy"
         const val ROW_COUNT = "rowCount"
 
@@ -162,7 +166,9 @@ class Preferences @Inject constructor(
         const val COLOR_ARGB = "color-argb"
         const val TUNNELING = "tunneling"
         const val ALWAYS_TV = "always-tv"
+        const val CLOCK_MODE = "12h-clock-mode"
         const val REMOTE_CONTROL = "remote-control"
+
         const val PROGRESS = "progress"
         const val ALWAYS_SHOW_REFRESH = "always-show-refresh"
         const val PAGING = "paging"

--- a/features/playlist/src/main/java/com/m3u/features/playlist/components/SmartphoneStreamItem.kt
+++ b/features/playlist/src/main/java/com/m3u/features/playlist/components/SmartphoneStreamItem.kt
@@ -245,9 +245,11 @@ internal fun SmartphoneStreamItem(
 private fun Programme.readText(
     timeColor: Color = MaterialTheme.colorScheme.secondary
 ): AnnotatedString = buildAnnotatedString {
+    val preferences = LocalPreferences.current
+    val clockMode = preferences.twelveHourClock
     val start = Instant.fromEpochMilliseconds(start)
         .toLocalDateTime(TimeZone.currentSystemDefault())
-        .formatEOrSh()
+        .formatEOrSh(clockMode)
     withStyle(
         SpanStyle(color = timeColor, fontWeight = FontWeight.SemiBold)
     ) {

--- a/features/setting/src/main/java/com/m3u/features/setting/fragments/preferences/RegularPreferences.kt
+++ b/features/setting/src/main/java/com/m3u/features/setting/fragments/preferences/RegularPreferences.kt
@@ -2,6 +2,7 @@ package com.m3u.features.setting.fragments.preferences
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AccessTime
 import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.DeviceHub
 import androidx.compose.material.icons.rounded.FitScreen
@@ -166,6 +167,14 @@ internal fun RegularPreferences(
         )
 
         CheckBoxSharedPreference(
+            title =  string.feat_setting_epg_clock_mode,
+            content = string.feat_setting_epg_clock_mode,
+            icon = Icons.Rounded.AccessTime,
+            checked = preferences.twelveHourClock,
+            onChanged = { preferences.twelveHourClock = !preferences.twelveHourClock }
+        )
+
+        CheckBoxSharedPreference(
             title = if (!tv) string.feat_setting_remote_control
             else string.feat_setting_remote_control_tv_side,
             content = if (!tv) string.feat_setting_remote_control_description
@@ -184,5 +193,6 @@ internal fun RegularPreferences(
                 onChanged = { preferences.godMode = !preferences.godMode }
             )
         }
+
     }
 }

--- a/features/setting/src/main/java/com/m3u/features/setting/fragments/preferences/RegularPreferences.kt
+++ b/features/setting/src/main/java/com/m3u/features/setting/fragments/preferences/RegularPreferences.kt
@@ -168,7 +168,6 @@ internal fun RegularPreferences(
 
         CheckBoxSharedPreference(
             title =  string.feat_setting_epg_clock_mode,
-            content = string.feat_setting_epg_clock_mode,
             icon = Icons.Rounded.AccessTime,
             checked = preferences.twelveHourClock,
             onChanged = { preferences.twelveHourClock = !preferences.twelveHourClock }
@@ -193,6 +192,5 @@ internal fun RegularPreferences(
                 onChanged = { preferences.godMode = !preferences.godMode }
             )
         }
-
     }
 }

--- a/features/stream/src/main/java/com/m3u/features/stream/components/ProgrammeGuide.kt
+++ b/features/stream/src/main/java/com/m3u/features/stream/components/ProgrammeGuide.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.zIndex
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.paging.compose.LazyPagingItems
 import coil.compose.AsyncImage
+import com.m3u.core.architecture.preferences.LocalPreferences
 import com.m3u.data.database.model.Programme
 import com.m3u.data.database.model.ProgrammeRange
 import com.m3u.data.database.model.ProgrammeRange.Companion.HOUR_LENGTH
@@ -292,7 +293,9 @@ private fun ProgrammeCell(
     modifier: Modifier = Modifier
 ) {
     val spacing = LocalSpacing.current
+    val preferences = LocalPreferences.current
     val colorScheme = MaterialTheme.colorScheme
+    val clockMode = preferences.twelveHourClock
     Surface(
         color = colorScheme.tertiaryContainer,
         border = BorderStroke(1.dp, colorScheme.outline),
@@ -314,7 +317,7 @@ private fun ProgrammeCell(
                 .toLocalDateTime(TimeZone.currentSystemDefault())
                 .toEOrSh()
             Text(
-                text = "${start.formatEOrSh()} - ${end.formatEOrSh()}",
+                text = "${start.formatEOrSh(clockMode)} - ${end.formatEOrSh(clockMode)}",
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodyMedium,
@@ -361,6 +364,8 @@ private fun CurrentTimelineCell(
     modifier: Modifier = Modifier
 ) {
     val spacing = LocalSpacing.current
+    val preferences = LocalPreferences.current
+    val clockMode = preferences.twelveHourClock
     val color = MaterialTheme.colorScheme.error
     val contentColor = MaterialTheme.colorScheme.onError
     val currentMilliseconds by rememberUpdatedState(milliseconds)
@@ -368,7 +373,7 @@ private fun CurrentTimelineCell(
         Instant
             .fromEpochMilliseconds(currentMilliseconds)
             .toLocalDateTime(TimeZone.currentSystemDefault())
-            .formatEOrSh()
+            .formatEOrSh(clockMode)
     }
     Box(contentAlignment = Alignment.CenterEnd) {
         Canvas(

--- a/i18n/src/main/res/values/feat_setting.xml
+++ b/i18n/src/main/res/values/feat_setting.xml
@@ -78,8 +78,7 @@
     <string name="feat_setting_canvas_apply">apply</string>
     <string name="feat_setting_canvas_reset">reset</string>
 
-    <string name="feat_setting_epg_clock_mode">12h clock mode</string>
-    <string name="epg_clock_mode_description">12h clock</string>
+    <string name="feat_setting_epg_clock_mode">epg 12h clock mode</string>
 
     <string name="feat_setting_remote_control">remote control</string>
     <string name="feat_setting_remote_control_description">turn on the ability to remotely control your TV</string>

--- a/i18n/src/main/res/values/feat_setting.xml
+++ b/i18n/src/main/res/values/feat_setting.xml
@@ -78,6 +78,9 @@
     <string name="feat_setting_canvas_apply">apply</string>
     <string name="feat_setting_canvas_reset">reset</string>
 
+    <string name="feat_setting_epg_clock_mode">12h clock mode</string>
+    <string name="epg_clock_mode_description">12h clock</string>
+
     <string name="feat_setting_remote_control">remote control</string>
     <string name="feat_setting_remote_control_description">turn on the ability to remotely control your TV</string>
 

--- a/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
+++ b/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
@@ -5,14 +5,37 @@ import kotlinx.datetime.LocalDateTime
 object TimeUtils {
     fun LocalDateTime.toEOrSh(): Float = run { hour + minute / 60f + second / 3600f }
 
-    fun LocalDateTime.formatEOrSh(): String =
-        "${if (hour < 10) "0$hour" else hour}:" +
-                "${if (minute < 10) "0$minute" else minute}:" +
-                "${if (second < 10) "0$second" else second}"
+    fun LocalDateTime.formatEOrSh(use12HourFormat: Boolean): String {
+        return if (use12HourFormat) {
+            val hour12 = if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
+            val amPm = if (hour < 12) "AM" else "PM"
+            val formattedHour = if (hour12 < 10) "0$hour12" else hour12.toString()
+            val formattedMinute = if (minute < 10) "0$minute" else minute.toString()
+            val formattedSecond = if (second < 10) "0$second" else second.toString()
+//        return "$formattedHour:$formattedMinute:$formattedSecond $amPm"
+            return "$formattedHour:$formattedMinute"
+        } else {
+            "${if (hour < 10) "0$hour" else hour}:" +
+            "${if (minute < 10) "0$minute" else minute}"// +
+//            ":${if (second < 10) "0$second" else second}"
+        }
+    }
+    fun Float.formatEOrSh(use12HourFormat: Boolean): String {
+        val hour = (this / 1).toInt()
+        val minute = (this % 1 * 60).toInt()
+        val amPm = if (hour < 12) "AM" else "PM"
+        val hour12 = if (use12HourFormat) {
+            if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
+        } else {
+            hour
+        }
+        val formattedHour = if (hour12 < 10) "0$hour12" else hour12.toString()
+        val formattedMinute = if (minute < 10) "0$minute" else minute.toString()
+        return if (use12HourFormat) {
+            "$formattedHour:$formattedMinute $amPm"
+        } else {
+            "$formattedHour:$formattedMinute"// $amPm"
+        }
 
-    fun Float.formatEOrSh(): String = buildString {
-        append((this@formatEOrSh / 1).toInt().let { if (it < 10) "0$it" else "$it" })
-        append(":")
-        append((this@formatEOrSh % 1 * 60).toInt().let { if (it < 10) "0$it" else "$it" })
     }
 }

--- a/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
+++ b/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
@@ -8,7 +8,7 @@ object TimeUtils {
     fun LocalDateTime.formatEOrSh(use12HourFormat: Boolean): String {
         return if (use12HourFormat) {
             val hour12 = if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
-            val amPm = if (hour < 12) "AM" else "PM"
+//            val amPm = if (hour < 12) "AM" else "PM"
             val formattedHour = if (hour12 < 10) "0$hour12" else hour12.toString()
             val formattedMinute = if (minute < 10) "0$minute" else minute.toString()
             val formattedSecond = if (second < 10) "0$second" else second.toString()
@@ -24,10 +24,11 @@ object TimeUtils {
         val hour = (this / 1).toInt()
         val minute = (this % 1 * 60).toInt()
         val amPm = if (hour < 12) "AM" else "PM"
-        val hour12 = if (use12HourFormat) {
-            if (hour > 12) hour - 12 else if (hour == 0) 12 else hour
-        } else {
-            hour
+        val hour12 = when {
+            !use12HourFormat -> hour
+            hour > 12 -> hour - 12
+            hour == 0 -> 12
+            else -> hour
         }
         val formattedHour = if (hour12 < 10) "0$hour12" else hour12.toString()
         val formattedMinute = if (minute < 10) "0$minute" else minute.toString()

--- a/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
+++ b/ui/src/main/java/com/m3u/ui/util/TimeUtils.kt
@@ -13,11 +13,11 @@ object TimeUtils {
             val formattedMinute = if (minute < 10) "0$minute" else minute.toString()
             val formattedSecond = if (second < 10) "0$second" else second.toString()
 //        return "$formattedHour:$formattedMinute:$formattedSecond $amPm"
-            return "$formattedHour:$formattedMinute"
+            return "$formattedHour:$formattedMinute:$formattedSecond"
         } else {
             "${if (hour < 10) "0$hour" else hour}:" +
-            "${if (minute < 10) "0$minute" else minute}"// +
-//            ":${if (second < 10) "0$second" else second}"
+            "${if (minute < 10) "0$minute" else minute}" +
+            ":${if (second < 10) "0$second" else second}"
         }
     }
     fun Float.formatEOrSh(use12HourFormat: Boolean): String {


### PR DESCRIPTION
by default 12H mode displays AM/PM after the time inside EPG listing. Needs translations