### PR TITLE
Add a Loading animation in the unstable video flow

### DIFF
--- a/ui/src/main/java/com/m3u/ui/Player.kt
+++ b/ui/src/main/java/com/m3u/ui/Player.kt
@@ -53,6 +53,7 @@ fun Player(
         factory = { context ->
             PlayerView(context).apply {
                 useController = false
+                setShowBuffering(PlayerView.SHOW_BUFFERING_ALWAYS)
             }
         },
         update = { view ->


### PR DESCRIPTION
## 1. When the video is not stable, adding a Loading animation
### When my network or m3u resources are unstable, I find it very strange that no animation is loaded but the picture is fixed to a certain frame.

- Before:

https://github.com/oxyroid/M3UAndroid/assets/108511706/a81b6411-6902-4e89-aec6-4c91be08d126

- After:

https://github.com/oxyroid/M3UAndroid/assets/108511706/e91e54a2-2306-4142-b6d2-f9b933714e22


