### PR TITLE
Fix connection timeout when add a large m3u playlist file

### DIFF
--- a/core/src/main/java/com/m3u/core/util/Files.kt
+++ b/core/src/main/java/com/m3u/core/util/Files.kt
@@ -4,6 +4,8 @@ import android.content.ContentResolver
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.core.net.toFile
+import java.io.File
+import java.io.IOException
 
 fun Uri.readFileName(resolver: ContentResolver): String? {
     return if (this == Uri.EMPTY) null
@@ -31,5 +33,19 @@ fun Uri.readFileContent(resolver: ContentResolver): String? {
             }
 
         else -> null
+    }
+}
+
+fun Uri.copyToFile(resolver: ContentResolver, destinationFile: File): Boolean {
+    return try {
+        resolver.openInputStream(this)?.use { inputStream ->
+            destinationFile.outputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        }
+        true
+    } catch (e: IOException) {
+        e.printStackTrace()
+        false
     }
 }


### PR DESCRIPTION
This PR addresses a critical OutOfMemoryError (OOM) issue encountered when handling large file allocations within the application. The primary change involves replacing the existing method of reading file contents directly into memory using **readText()** with a more efficient streaming approach via the **copyToFile** function. This enhancement ensures that the application manages memory more effectively, thereby improving stability and performance when processing large files.