### PR TITLE
Italian Translation

### DIFF
--- a/i18n/src/main/res/values-it-rIT/app.xml
+++ b/i18n/src/main/res/values-it-rIT/app.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_label_crash">arresti anomali dell\'app</string>
+    <string name="app_shortcut_channel_recently_short_label">Recenti</string>
+    <string name="app_shortcut_channel_recently_long_label">Riproduci canale recenti</string>
+    <string name="app_shortcut_channel_recently_disabled">non disponibile</string>
+    <string name="crash_notification_title">Ops! L\'app si è bloccata</string>
+    <string name="crash_notification_text">Il log è stato conservato, potrai condividerlo con noi più tardi!</string>
+    <string name="crash_notification_channel_name">Protetto</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/data.xml
+++ b/i18n/src/main/res/values-it-rIT/data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="data_error_file_not_found">file non trovato</string>
+    <string name="data_error_empty_title">il nome della playlist è vuoto</string>
+    <string name="data_channel_name_stream_download_service">Servizio Download Stream</string>
+    <string name="data_channel_description_stream_download_service">Descrizione Download Stream</string>
+
+    <string name="data_worker_subscription_action_cancel">Annulla</string>
+    <string name="data_worker_subscription_action_retry">Riprova</string>
+    <string name="data_worker_subscription_content_completed">Completati (+%d)</string>
+    <string name="data_worker_subscription_content_channel_progress">%d canali sono stati scaricati</string>
+    <string name="data_worker_subscription_content_programme_progress">%d programmi sono stati scaricati</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_about.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_about.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_about_title">informazioni sul progetto</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_console.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_console.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_console_title">Editor della console</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_favourite.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_favourite.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_favorite_scheme_unknown">sconosciuto</string>
+    <string name="feat_favorite_play_randomly">esegui in modo casuale</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_foryou.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_foryou.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_foryou_hidden_channels_playlist">canali nascosti</string>
+    <string name="feat_foryou_unsubscribe_playlist">annulla iscrizione</string>
+    <string name="feat_foryou_copy_playlist_url">copia url</string>
+    <string name="feat_foryou_rename_playlist">rinomina</string>
+    <string name="feat_foryou_imported_playlist_title">importate</string>
+    <string name="feat_foryou_prompt_add_playlist">aggiungi una playlist</string>
+    <string name="feat_foryou_recommend_unseen_label">preferiti che vorresti rivedere</string>
+    <string name="feat_foryou_recommend_unseen_more_than_days">più di %d giorni</string>
+    <string name="feat_foryou_recommend_unseen_days">%d giorni</string>
+    <string name="feat_foryou_recommend_unseen_hours">%d ore</string>
+    <string name="feat_foryou_recommend_cw_label">continua a guardare</string>
+    <string name="feat_foryou_new_release">nuova release</string>
+    <string name="feat_foryou_connect_title">inserisci il codice dalla TV</string>
+    <string name="feat_foryou_connect_subtitle">Assicurati di essere connesso alla stessa rete Wi-Fi</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_playlist.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_playlist.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_playlist_scheme_unknown">sconosciuto</string>
+    <string name="feat_playlist_dialog_favourite_title">mi piace</string>
+    <string name="feat_playlist_dialog_favourite_cancel_title">rimuovi mi piace</string>
+    <string name="feat_playlist_dialog_hide_title">nascondi</string>
+    <string name="feat_playlist_dialog_save_picture_title">salva in galleria</string>
+    <string name="feat_playlist_dialog_create_shortcut_title">crea collegamento</string>
+    <string name="feat_playlist_error_playlist_not_found">la playlist non esiste (%s)</string>
+    <string name="feat_playlist_query_placeholder">inserisci parola chiave</string>
+    <string name="feat_playlist_error_playlist_url_not_found">l\'url della playlist non esiste</string>
+    <string name="feat_playlist_error_channel_cover_not_found">la copertina non esiste</string>
+    <string name="feat_playlist_error_channel_not_found">il canale non esiste</string>
+    <string name="feat_playlist_success_save_cover">salvato in (%s)</string>
+    <string name="feat_playlist_scroll_up">scorri in alto</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_playlist_configuration.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_playlist_configuration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_playlist_configuration_title">titolo</string>
+    <string name="feat_playlist_configuration_user_agent">user agent</string>
+    <string name="feat_playlist_configuration_enabled_epgs">EPG abilitati</string>
+    <string name="feat_playlist_configuration_sync_programmes">sincronizza programmi</string>
+    <string name="feat_playlist_configuration_cancel_sync_programmes">annulla sincronizzazione programmi</string>
+    <string name="feat_playlist_configuration_programmes_expired_time">Scadenza: %s</string>
+    <string name="feat_playlist_configuration_programmes_expired">I programmi memorizzati non sono aggiornati</string>
+    <string name="feat_playlist_configuration_auto_refresh_programmes">Aggiorna automaticamente programmi</string>
+    <string name="feat_playlist_configuration_auto_refresh_programmes_description">All\'avvio dell\'app</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_setting.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_setting.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_setting_app_version">versione app</string>
+    <string name="feat_setting_label_subscribe">iscriviti</string>
+    <string name="feat_setting_success_subscribe">iscrizione completata</string>
+    <string name="feat_setting_failed_malformed_url">url non valido (%s)</string>
+    <string name="feat_setting_error_empty_title">il nome della playlist è vuoto</string>
+    <string name="feat_setting_placeholder_title">nome playlist</string>
+    <string name="feat_setting_placeholder_url">link playlist</string>
+    <string name="feat_setting_label_subscribing">iscrizione in corso</string>
+    <string name="feat_setting_sync_mode_all">tutti</string>
+    <string name="feat_setting_sync_mode_keep">mantieni</string>
+    <string name="feat_setting_sync_mode">strategia di sincronizzazione</string>
+    <string name="feat_setting_playlist_management">gestione playlist</string>
+    <string name="feat_setting_connect_timeout">timeout di connessione</string>
+    <string name="feat_setting_god_mode">modalità esperto</string>
+    <string name="feat_setting_god_mode_description">regola il layout con i tasti volume fisici</string>
+    <string name="feat_setting_experimental_mode">modalità sperimentale</string>
+    <string name="feat_setting_experimental_mode_description">le funzionalità instabili possono causare errori critici</string>
+    <string name="feat_setting_label_epg_playlists">Lista EPG</string>
+    <string name="feat_setting_label_hidden_channels">canali nascosti</string>
+    <string name="feat_setting_label_hidden_playlist_groups">categorie playlist nascoste</string>
+    <string name="feat_setting_label_add_playlist">aggiungi playlist</string>
+    <string name="feat_setting_label_parse_from_clipboard">analizza appunti</string>
+    <string name="feat_setting_label_select_from_local_storage">seleziona file</string>
+    <string name="feat_setting_label_parse_from_disk">analizza file</string>
+    <string name="feat_setting_clip_mode">modalità video clip</string>
+    <string name="feat_setting_clip_mode_adaptive">adattivo</string>
+    <string name="feat_setting_clip_mode_clip">clip</string>
+    <string name="feat_setting_clip_mode_stretched">esteso</string>
+    <string name="feat_setting_auto_refresh_channels">aggiorna canali automaticamente</string>
+    <string name="feat_setting_auto_refresh_channels_description">aggiornamento automatico all\'ingresso nel canale</string>
+
+    <string name="feat_setting_full_info_player">player con informazioni complete</string>
+    <string name="feat_setting_full_info_player_description">mostra più informazioni nel player</string>
+    <string name="feat_setting_slider">slider</string>
+    <string name="feat_setting_no_picture_mode">modalità senza immagini</string>
+    <string name="feat_setting_no_picture_mode_description">può migliorare le prestazioni</string>
+    <string name="feat_setting_system_setting">impostazioni di sistema</string>
+    <string name="feat_setting_script_management_import_js">importa Javascript</string>
+    <string name="feat_setting_enqueue_subscribe">un subscription task è stato aggiunto alla coda</string>
+    <string name="feat_setting_dropbox">dropbox</string>
+    <string name="feat_setting_project_about">informazioni sul progetto</string>
+    <string name="feat_setting_local_storage">archivio locale</string>
+    <string name="feat_setting_error_unselected_file">nessun file selezionato</string>
+    <string name="feat_setting_error_blank_url">url vuoto</string>
+    <string name="feat_setting_use_dynamic_colors">colori dinamici</string>
+    <string name="feat_setting_use_dynamic_colors_unavailable">disponibile su Android 12 e versioni successive</string>
+    <string name="feat_setting_colorful_background">sfondo colorato</string>
+    <string name="feat_setting_restore_schemes">ripristina schemi</string>
+    <string name="feat_setting_not_implementation">questa funzionalità non è disponibile nella versione attuale</string>
+    <string name="feat_setting_zapping_mode">modalità zapping</string>
+    <string name="feat_setting_zapping_mode_description">anteprima rapida prima di riprodurre il canale</string>
+    <string name="feat_setting_gesture_brightness">gesture luminosità</string>
+    <string name="feat_setting_gesture_volume">gesture volume</string>
+    <string name="feat_setting_screencast">trasmissione schermo</string>
+    <string name="feat_setting_screen_rotating">rotazione schermo</string>
+    <string name="feat_setting_screen_rotating_description">disponibile quando la rotazione di sistema è sbloccata</string>
+    <string name="feat_setting_optional_features">funzionalità opzionali</string>
+    <string name="feat_setting_unseen_limit">mostra canali preferiti non visti di recente</string>
+    <string name="feat_setting_reconnect_mode">riconnessione automatica</string>
+    <string name="feat_setting_reconnect_mode_no">mai</string>
+    <string name="feat_setting_reconnect_mode_retry">solo in caso di errore</string>
+    <string name="feat_setting_reconnect_mode_reconnect">sempre</string>
+
+    <string name="feat_setting_appearance">aspetto</string>
+    <string name="feat_setting_appearance_hint_edit_color">tieni premuto per modificare il colore</string>
+
+    <string name="feat_setting_tunneling">modalità tunneling</string>
+    <string name="feat_setting_tunneling_description">migliora la riproduzione di contenuti 4K/HDR</string>
+    <string name="feat_setting_label_backup">backup</string>
+    <string name="feat_setting_label_restore">ripristina</string>
+
+    <string name="feat_setting_canvas_dark">scuro</string>
+    <string name="feat_setting_canvas_light">chiaro</string>
+    <string name="feat_setting_canvas_apply">applica</string>
+    <string name="feat_setting_canvas_reset">ripristina</string>
+
+    <string name="feat_setting_epg_clock_mode">modalità programmazione orario 12h</string>
+
+    <string name="feat_setting_remote_control">controllo remoto</string>
+    <string name="feat_setting_remote_control_description">attiva la possibilità di controllare la TV da remoto</string>
+
+    <string name="feat_setting_remote_control_tv_side">controllo remoto</string>
+    <string name="feat_setting_remote_control_tv_side_description">consenti agli smartphone di controllare la tua TV</string>
+
+    <string name="feat_setting_subscribe_for_tv">per TV</string>
+
+    <string name="feat_setting_backing_up">backup in corso di tutte le playlist e canali</string>
+    <string name="feat_setting_restoring">ripristino in corso di tutte le playlist e canali</string>
+
+    <string name="feat_setting_follow_system_theme">segui tema di sistema</string>
+
+    <string name="feat_setting_data_source_m3u" translatable="false">M3U</string>
+    <string name="feat_setting_data_source_epg" translatable="false">EPG</string>
+    <string name="feat_setting_data_source_xtream" translatable="false">Xtream</string>
+    <string name="feat_setting_data_source_emby" translatable="false">Emby</string>
+    <string name="feat_setting_data_source_dropbox" translatable="false">Dropbox</string>
+
+    <string name="feat_setting_placeholder_basic_url">indirizzo</string>
+    <string name="feat_setting_placeholder_username">username</string>
+    <string name="feat_setting_placeholder_password">password</string>
+
+    <string name="feat_setting_warning_xtream_takes_much_more_time">potrebbe richiedere molto più tempo</string>
+
+    <string name="feat_setting_back_home">torna alla home</string>
+
+    <string name="feat_setting_always_replay">mostra sempre pulsante replay</string>
+
+    <string name="feat_setting_player_panel">pannello player</string>
+    <string name="feat_setting_player_panel_description">scorri verso l\'alto il player per espanderlo in modalità verticale</string>
+
+    <string name="feat_setting_cache">cache durante la riproduzione</string>
+    <string name="feat_setting_cache_description">questa opzione potrebbe impedire la riproduzione normale</string>
+    <string name="feat_setting_clear_cache">svuota cache</string>
+
+    <string name="feat_setting_paging">paginazione canali</string>
+    <string name="feat_setting_paging_description">
+        utile per grandi quantità di canali,
+        ma contemporaneamente il raggruppamento verrà disabilitato 
+    </string>
+    <string name="feat_setting_source_code">codice sorgente</string>
+
+    <string name="feat_setting_compact_dimension">dimensione compatta</string>
+    <!-- EPG -->
+    <string name="feat_setting_placeholder_epg_title">nome epg</string>
+    <string name="feat_setting_error_empty_epg_title">il nome epg è vuoto</string>
+    <string name="feat_setting_error_empty_epg">il link epg è vuoto</string>
+    <string name="feat_setting_placeholder_epg">link epg</string>
+    <string name="feat_setting_epg_added">puoi associare la playlist all\'EPG</string>
+
+    <string name="feat_setting_randomly_in_favourite">riproduzione casuale solo dai preferiti</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/feat_stream.xml
+++ b/i18n/src/main/res/values-it-rIT/feat_stream.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_channel_playback_state_idle">inattivo</string>
+    <string name="feat_channel_playback_state_buffering">caricamento</string>
+    <string name="feat_channel_playback_state_ready">pronto</string>
+    <string name="feat_channel_playback_state_ended">completato</string>
+
+    <string name="feat_channel_tooltip_on_back_pressed">indietro</string>
+    <string name="feat_channel_tooltip_mute">disattiva audio</string>
+    <string name="feat_channel_tooltip_unmute">attiva audio</string>
+    <string name="feat_channel_tooltip_favourite">aggiungi ai preferiti</string>
+    <string name="feat_channel_tooltip_unfavourite">rimuovi dai preferiti</string>
+    <string name="feat_channel_tooltip_download">scarica</string>
+    <string name="feat_channel_tooltip_stop_download">interrompi download</string>
+    <string name="feat_channel_tooltip_cast">trasmetti schermo</string>
+    <string name="feat_channel_tooltip_open_panel">apri pannello</string>
+    <string name="feat_channel_tooltip_enter_pip_mode">modalità PIP</string>
+    <string name="feat_channel_tooltip_screen_rotating">rotazione schermo</string>
+    <string name="feat_channel_tooltip_choose_format">scegli formato</string>
+
+    <string name="feat_channel_dialog_dlna_devices">Dispositivi DLNA</string>
+    <string name="feat_channel_dialog_choose_tracks">Scegli tracce</string>
+
+    <string name="feat_channel_open_in_external_app">apri in app esterna</string>
+
+    <string name="feat_channel_cw_position_title">Ultima riproduzione a %s</string>
+    <string name="feat_channel_cw_position_button">Riavvolgi</string>
+</resources>

--- a/i18n/src/main/res/values-it-rIT/ui.xml
+++ b/i18n/src/main/res/values-it-rIT/ui.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ui_title_foryou">M3U</string>
+    <string name="ui_title_favourite">Preferiti</string>
+    <string name="ui_title_setting">Impostazioni</string>
+
+    <string name="ui_destination_foryou">Per te</string>
+    <string name="ui_destination_favourite">Preferiti</string>
+    <string name="ui_destination_extension">Estensioni</string>
+    <string name="ui_destination_setting">Impostazioni</string>
+    <string name="ui_destination_playlist">Playlist</string>
+
+    <string name="ui_error_unknown">errore sconosciuto</string>
+    <string name="ui_cd_top_bar_on_back_pressed">indietro</string>
+
+    <string name="ui_theme_card_left">Lo sapevi?</string>
+    <string name="ui_theme_card_right">Salveremo i tuoi **progressi di visione** e riprenderai da dove avevi lasciato</string>
+
+    <string name="ui_sort">Ordina</string>
+    <string name="ui_sort_asc">A-Z</string>
+    <string name="ui_sort_desc">Z-A</string>
+    <string name="ui_sort_recently">Recenti</string>
+    <string name="ui_sort_mixed">Mixed</string>
+    <string name="ui_sort_never_played">mai riprodotti</string>
+    <string name="ui_sort_unspecified">Non specificato</string>
+
+    <string name="ui_connect">Connetti</string>
+</resources>


### PR DESCRIPTION
Hi,
I’ve added full support for the Italian language, identified as "values-it-rIT".
I’ve included the localization of all strings, ensuring consistency with the original version.
In some cases, I aligned the terminology with standard Italian usage, aiming to maintain good readability and clarity in the texts.
This contribution will surely be appreciated by all Italian-speaking users, making the project more accessible.
Luca