### PR TITLE
Add Swedish (sv-SE) translation

### DIFF
--- a/i18n/src/main/res/values-sv-rSE/app.xml
+++ b/i18n/src/main/res/values-sv-rSE/app.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_label_crash">appen kraschar</string>
+    <string name="app_shortcut_channel_recently_short_label">Nyligen</string>
+    <string name="app_shortcut_channel_recently_long_label">Spela senaste kanal</string>
+    <string name="app_shortcut_channel_recently_disabled">otillgänglig</string>
+    <string name="crash_notification_title">Hoppsan! Appen kraschade</string>
+    <string name="crash_notification_text">Spårningen har samlats in, du kan dela den med oss senare!</string>
+    <string name="crash_notification_channel_name">Skyddad</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/data.xml
+++ b/i18n/src/main/res/values-sv-rSE/data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="data_error_file_not_found">filen hittades inte</string>
+    <string name="data_error_empty_title">spellistans namn är tomt</string>
+    <string name="data_channel_name_stream_download_service">Tjänst för nedladdning av ström</string>
+    <string name="data_channel_description_stream_download_service">Beskrivning av strömnedladdning</string>
+
+    <string name="data_worker_subscription_action_cancel">Avbryt</string>
+    <string name="data_worker_subscription_action_retry">Försök igen</string>
+    <string name="data_worker_subscription_content_completed">Slutförd (+%d)</string>
+    <string name="data_worker_subscription_content_channel_progress">%d kanaler har laddats ner</string>
+    <string name="data_worker_subscription_content_programme_progress">%d program har laddats ner</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_about.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_about.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_about_title">om projektet</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_console.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_console.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_console_title">Konsol-editor</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_favourite.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_favourite.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_favorite_scheme_unknown">okänd</string>
+    <string name="feat_favorite_play_randomly">spela slumpmässigt</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_foryou.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_foryou.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_foryou_hidden_channels_playlist">dolda kanaler</string>
+    <string name="feat_foryou_unsubscribe_playlist">avsluta prenumeration</string>
+    <string name="feat_foryou_copy_playlist_url">kopiera URL</string>
+    <string name="feat_foryou_rename_playlist">byt namn</string>
+    <string name="feat_foryou_imported_playlist_title">importerad</string>
+    <string name="feat_foryou_prompt_add_playlist">lägg till en spellista</string>
+    <string name="feat_foryou_recommend_unseen_label">favorit som du skulle vilja se igen</string>
+    <string name="feat_foryou_recommend_unseen_more_than_days">mer än %d dagar</string>
+    <string name="feat_foryou_recommend_unseen_days">%d dagar</string>
+    <string name="feat_foryou_recommend_unseen_hours">%d timmar</string>
+    <string name="feat_foryou_recommend_cw_label">fortsätt titta</string>
+    <string name="feat_foryou_new_release">ny utgåva</string>
+    <string name="feat_foryou_connect_title">ange kod från TV</string>
+    <string name="feat_foryou_connect_subtitle">Se till att ansluta till samma Wi-Fi</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_playlist.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_playlist.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_playlist_scheme_unknown">okänd</string>
+    <string name="feat_playlist_dialog_favourite_title">gilla</string>
+    <string name="feat_playlist_dialog_favourite_cancel_title">avbryt gilla</string>
+    <string name="feat_playlist_dialog_hide_title">dölj</string>
+    <string name="feat_playlist_dialog_save_picture_title">spara i galleri</string>
+    <string name="feat_playlist_dialog_create_shortcut_title">skapa genväg</string>
+    <string name="feat_playlist_error_playlist_not_found">spellistan finns inte (%s)</string>
+    <string name="feat_playlist_query_placeholder">ange sökord</string>
+    <string name="feat_playlist_error_playlist_url_not_found">spellistans URL finns inte</string>
+    <string name="feat_playlist_error_channel_cover_not_found">omslag finns inte</string>
+    <string name="feat_playlist_error_channel_not_found">kanalen finns inte</string>
+    <string name="feat_playlist_success_save_cover">sparad i (%s)</string>
+    <string name="feat_playlist_scroll_up">scrolla upp</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_playlist_configuration.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_playlist_configuration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_playlist_configuration_title">titel</string>
+    <string name="feat_playlist_configuration_user_agent">user agent</string>
+    <string name="feat_playlist_configuration_enabled_epgs">aktiverade EPG:er</string>
+    <string name="feat_playlist_configuration_sync_programmes">synkronisera program</string>
+    <string name="feat_playlist_configuration_cancel_sync_programmes">avbryt synkronisering av program</string>
+    <string name="feat_playlist_configuration_programmes_expired_time">Utgår: %s</string>
+    <string name="feat_playlist_configuration_programmes_expired">Cachade program är föråldrade</string>
+    <string name="feat_playlist_configuration_auto_refresh_programmes">Uppdatera program automatiskt</string>
+    <string name="feat_playlist_configuration_auto_refresh_programmes_description">Vid appstart</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_setting.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_setting.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_setting_app_version">appversion</string>
+    <string name="feat_setting_label_subscribe">prenumerera</string>
+    <string name="feat_setting_success_subscribe">prenumeration lyckades</string>
+    <string name="feat_setting_failed_malformed_url">felaktig URL (%s)</string>
+    <string name="feat_setting_error_empty_title">spellistans namn är tomt</string>
+    <string name="feat_setting_placeholder_title">spellistans namn</string>
+    <string name="feat_setting_placeholder_url">spellistans länk</string>
+    <string name="feat_setting_label_subscribing">prenumererar</string>
+    <string name="feat_setting_sync_mode_all">alla</string>
+    <string name="feat_setting_sync_mode_keep">behåll</string>
+    <string name="feat_setting_sync_mode">synkroniseringsstrategi</string>
+    <string name="feat_setting_playlist_management">hantera spellistor</string>
+    <string name="feat_setting_connect_timeout">timeout för anslutning</string>
+    <string name="feat_setting_god_mode">god mode</string>
+    <string name="feat_setting_god_mode_description">justera layouter med fysiska volymknappar</string>
+    <string name="feat_setting_experimental_mode">experimentläge</string>
+    <string name="feat_setting_experimental_mode_description">instabila funktioner kan orsaka allvarliga fel</string>
+    <string name="feat_setting_label_epg_playlists">EPG-lista</string>
+    <string name="feat_setting_label_hidden_channels">dolda kanaler</string>
+    <string name="feat_setting_label_hidden_playlist_groups">dolda spellistekategorier</string>
+    <string name="feat_setting_label_add_playlist">lägg till spellista</string>
+    <string name="feat_setting_label_parse_from_clipboard">tolka urklipp</string>
+    <string name="feat_setting_label_select_from_local_storage">välj fil</string>
+    <string name="feat_setting_label_parse_from_disk">tolka fil</string>
+    <string name="feat_setting_clip_mode">videoklippläge</string>
+    <string name="feat_setting_clip_mode_adaptive">adaptivt</string>
+    <string name="feat_setting_clip_mode_clip">beskär</string>
+    <string name="feat_setting_clip_mode_stretched">sträckt</string>
+    <string name="feat_setting_auto_refresh_channels">uppdatera kanaler automatiskt</string>
+    <string name="feat_setting_auto_refresh_channels_description">uppdateras automatiskt när du går in i kanalen</string>
+
+    <string name="feat_setting_full_info_player">fullständig informationsspelare</string>
+    <string name="feat_setting_full_info_player_description">visa mer information i spelaren</string>
+    <string name="feat_setting_slider">skjutreglage</string>
+    <string name="feat_setting_no_picture_mode">bildlöst läge</string>
+    <string name="feat_setting_no_picture_mode_description">kan förbättra prestandan</string>
+    <string name="feat_setting_system_setting">systeminställningar</string>
+    <string name="feat_setting_script_management_import_js">importera Javascript</string>
+    <string name="feat_setting_enqueue_subscribe">en prenumerationsuppgift har lagts till i kön</string>
+    <string name="feat_setting_dropbox">dropbox</string>
+    <string name="feat_setting_project_about">om projektet</string>
+    <string name="feat_setting_local_storage">lokal lagring</string>
+    <string name="feat_setting_error_unselected_file">ingen fil vald än</string>
+    <string name="feat_setting_error_blank_url">tom URL</string>
+    <string name="feat_setting_use_dynamic_colors">dynamiska färger</string>
+    <string name="feat_setting_use_dynamic_colors_unavailable">tillgängligt på Android 12 och högre</string>
+    <string name="feat_setting_colorful_background">färgglad bakgrund</string>
+    <string name="feat_setting_restore_schemes">återställ scheman</string>
+    <string name="feat_setting_not_implementation">denna funktion är inte tillgänglig för nuvarande version</string>
+    <string name="feat_setting_zapping_mode">zappingläge</string>
+    <string name="feat_setting_zapping_mode_description">snabbförhandsvisning innan kanal spelas</string>
+    <string name="feat_setting_gesture_brightness">ljusstyrkegest</string>
+    <string name="feat_setting_gesture_volume">volymgest</string>
+    <string name="feat_setting_screencast">skärmdelning</string>
+    <string name="feat_setting_screen_rotating">skärmrotation</string>
+    <string name="feat_setting_screen_rotating_description">tillgänglig när systemrotation är upplåst</string>
+    <string name="feat_setting_optional_features">valfria funktioner</string>
+    <string name="feat_setting_unseen_limit">rekommendera längesedan sedda favoritkanaler</string>
+    <string name="feat_setting_reconnect_mode">återanslut automatiskt</string>
+    <string name="feat_setting_reconnect_mode_no">aldrig</string>
+    <string name="feat_setting_reconnect_mode_retry">endast vid fel</string>
+    <string name="feat_setting_reconnect_mode_reconnect">alltid</string>
+
+    <string name="feat_setting_appearance">utseende</string>
+    <string name="feat_setting_appearance_hint_edit_color">långtryck för att redigera färg</string>
+
+    <string name="feat_setting_tunneling">tunnelläge</string>
+    <string name="feat_setting_tunneling_description">förbättra uppspelning av 4K/HDR-innehåll</string>
+    <string name="feat_setting_label_backup">säkerhetskopiera</string>
+    <string name="feat_setting_label_restore">återställ</string>
+
+    <string name="feat_setting_canvas_dark">mörk</string>
+    <string name="feat_setting_canvas_light">ljus</string>
+    <string name="feat_setting_canvas_apply">tillämpa</string>
+    <string name="feat_setting_canvas_reset">återställ</string>
+
+    <string name="feat_setting_epg_clock_mode">program 12-timmars klockläge</string>
+
+    <string name="feat_setting_remote_control">fjärrkontroll</string>
+    <string name="feat_setting_remote_control_description">aktivera möjligheten att fjärrstyra din TV</string>
+
+    <string name="feat_setting_remote_control_tv_side">fjärrkontroll</string>
+    <string name="feat_setting_remote_control_tv_side_description">låt smartphones styra din TV</string>
+
+    <string name="feat_setting_subscribe_for_tv">för TV</string>
+
+    <string name="feat_setting_backing_up">säkerhetskopierar alla spellistor och kanaler</string>
+    <string name="feat_setting_restoring">återställer alla spellistor och kanaler</string>
+
+    <string name="feat_setting_follow_system_theme">följ systemtema</string>
+
+    <string name="feat_setting_data_source_m3u" translatable="false">M3U</string>
+    <string name="feat_setting_data_source_epg" translatable="false">EPG</string>
+    <string name="feat_setting_data_source_xtream" translatable="false">Xtream</string>
+    <string name="feat_setting_data_source_emby" translatable="false">Emby</string>
+    <string name="feat_setting_data_source_dropbox" translatable="false">Dropbox</string>
+
+    <string name="feat_setting_placeholder_basic_url">adress</string>
+    <string name="feat_setting_placeholder_username">användarnamn</string>
+    <string name="feat_setting_placeholder_password">lösenord</string>
+
+    <string name="feat_setting_warning_xtream_takes_much_more_time">det kan ta mycket längre tid</string>
+
+    <string name="feat_setting_back_home">tillbaka hem</string>
+
+    <string name="feat_setting_always_replay">visa alltid uppspelningsknapp</string>
+
+    <string name="feat_setting_player_panel">spelarpanel</string>
+    <string name="feat_setting_player_panel_description">svep upp spelaren för att utöka den i stående läge</string>
+
+    <string name="feat_setting_cache">cache under uppspelning</string>
+    <string name="feat_setting_cache_description">detta alternativ kan förhindra normal uppspelning</string>
+    <string name="feat_setting_clear_cache">rensa cache</string>
+
+    <string name="feat_setting_paging">sidindela kanaler</string>
+    <string name="feat_setting_paging_description">
+        användbart för stora mängder kanaler,
+        men gruppering kommer att inaktiveras samtidigt
+    </string>
+    <string name="feat_setting_source_code">källkod</string>
+
+    <string name="feat_setting_compact_dimension">kompakt storlek</string>
+    <!-- EPG -->
+    <string name="feat_setting_placeholder_epg_title">EPG-namn</string>
+    <string name="feat_setting_error_empty_epg_title">EPG-namnet är tomt</string>
+    <string name="feat_setting_error_empty_epg">EPG-länken är tom</string>
+    <string name="feat_setting_placeholder_epg">EPG-länk</string>
+    <string name="feat_setting_epg_added">du kan sedan associera spellistan med EPG</string>
+
+    <string name="feat_setting_randomly_in_favourite">spela slumpmässigt endast från favoriter</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/feat_stream.xml
+++ b/i18n/src/main/res/values-sv-rSE/feat_stream.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feat_channel_playback_state_idle">inaktiv</string>
+    <string name="feat_channel_playback_state_buffering">buffrar</string>
+    <string name="feat_channel_playback_state_ready">klar</string>
+    <string name="feat_channel_playback_state_ended">slutförd</string>
+
+    <string name="feat_channel_tooltip_on_back_pressed">tillbaka</string>
+    <string name="feat_channel_tooltip_mute">tysta</string>
+    <string name="feat_channel_tooltip_unmute">slå på ljud</string>
+    <string name="feat_channel_tooltip_favourite">favorit</string>
+    <string name="feat_channel_tooltip_unfavourite">ta bort favorit</string>
+    <string name="feat_channel_tooltip_download">ladda ner</string>
+    <string name="feat_channel_tooltip_stop_download">stoppa nedladdning</string>
+    <string name="feat_channel_tooltip_cast">strömma skärm</string>
+    <string name="feat_channel_tooltip_open_panel">öppna panel</string>
+    <string name="feat_channel_tooltip_enter_pip_mode">PIP-läge</string>
+    <string name="feat_channel_tooltip_screen_rotating">skärmrotation</string>
+    <string name="feat_channel_tooltip_choose_format">välj format</string>
+
+    <string name="feat_channel_dialog_dlna_devices">DLNA-enheter</string>
+    <string name="feat_channel_dialog_choose_tracks">Välj spår</string>
+
+    <string name="feat_channel_open_in_external_app">öppna i extern app</string>
+
+    <string name="feat_channel_cw_position_title">Senast spelad vid %s</string>
+    <string name="feat_channel_cw_position_button">Spola tillbaka</string>
+</resources>

--- a/i18n/src/main/res/values-sv-rSE/ui.xml
+++ b/i18n/src/main/res/values-sv-rSE/ui.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ui_title_foryou">M3U</string>
+    <string name="ui_title_favourite">Favorit</string>
+    <string name="ui_title_setting">Inställningar</string>
+
+    <string name="ui_destination_foryou">För Dig</string>
+    <string name="ui_destination_favourite">Favorit</string>
+    <string name="ui_destination_extension">Tillägg</string>
+    <string name="ui_destination_setting">Inställningar</string>
+    <string name="ui_destination_playlist">Spellista</string>
+
+    <string name="ui_error_unknown">okänt fel</string>
+    <string name="ui_cd_top_bar_on_back_pressed">tillbaka</string>
+
+    <string name="ui_theme_card_left">Visste du?</string>
+    <string name="ui_theme_card_right">Vi kommer att spara din **visningshistorik** och återuppta nästa gång du spelar</string>
+
+    <string name="ui_sort">Sortera</string>
+    <string name="ui_sort_asc">A-Ö</string>
+    <string name="ui_sort_desc">Ö-A</string>
+    <string name="ui_sort_recently">Nyligen</string>
+    <string name="ui_sort_mixed">Blandad</string>
+    <string name="ui_sort_never_played">aldrig spelad</string>
+    <string name="ui_sort_unspecified">Ospecificerad</string>
+
+    <string name="ui_connect">Anslut</string>
+</resources>


### PR DESCRIPTION
Added complete Swedish translation with 203 strings across 11 XML files:
- ui.xml (20 strings) - Main UI navigation
- feat_stream.xml (21 strings) - Video player controls
- feat_playlist.xml (13 strings) - Playlist management
- feat_setting.xml (106 strings) - Settings
- feat_foryou.xml (14 strings) - Home screen
- feat_playlist_configuration.xml (9 strings)
- data.xml (9 strings) - Notifications
- app.xml (7 strings) - App-level resources
- feat_favourite.xml (2 strings)
- feat_console.xml (1 string)
- feat_about.xml (1 string)

Technical terms (M3U, EPG, IPTV, DLNA) preserved.
All format placeholders and markdown formatting maintained.