### PR TITLE
Expand GitHub issue templates with playback and TV-focus forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,15 +1,47 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
+about: Report a reproducible app problem
+title: '[Bug] '
 labels: bug
 assignees: ''
 
 ---
 
 **Check before feedback**
-- [ ] I checked the other issues to ensure no one has mentioned it yet.
-- [ ] I made sure the bug can be reproduced in the [SNAPSHOT](https://nightly.link/oxyroid/M3UAndroid/workflows/android/master/artifact.zip) application package.
+- [ ] I checked existing issues to ensure this has not already been reported.
+- [ ] I reproduced the bug on the latest GitHub Release or Nightly build when possible.
+- [ ] I removed or masked private playlist URLs, tokens, usernames, passwords, and server addresses.
+
+**App variant**
+- [ ] Smartphone
+- [ ] TV
+
+**Installation source**
+- [ ] GitHub Release
+- [ ] Nightly
+- [ ] Self-built
+
+**App version / build**
+- Version or commit: [e.g. 1.10.2 or commit SHA]
+
+**Device and Android environment**
+- Device model: [e.g. Google Pixel 8, Chromecast with Google TV]
+- Android version: [e.g. Android 14]
+- Is this an Android TV device?
+  - [ ] Yes
+  - [ ] No
+  - [ ] Not sure
+
+**Problem type**
+- [ ] Playback
+- [ ] EPG
+- [ ] Playlist
+- [ ] Xtream API
+- [ ] DLNA
+- [ ] Sync
+- [ ] UI
+- [ ] Performance
+- [ ] Other:
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -18,21 +50,26 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Select '...'
+3. Open or play '...'
 4. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Playlist / provider context**
+- Playlist type:
+  - [ ] M3U
+  - [ ] Xtream API
+  - [ ] Local file
+  - [ ] Other:
+- Can you provide a sanitized sample playlist, channel entry, or provider response?
+  - [ ] Yes, attached below
+  - [ ] No, private provider data
+  - [ ] Not applicable
 
-**Smartphone (please complete the following information):**
-
-- Device: [e.g. Google Pixel 4XL]
-- OS: [e.g. Android 12]
-- Version [e.g. 1.10.2]
+**Crash log, screenshot, or screen recording**
+Attach crash logs, Logcat output, screenshots, or screen recordings if available. Please remove private URLs and credentials.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Telegram Channel
+    url: https://t.me/m3u_android
+    about: Follow project updates and community announcements.
+  - name: README / Getting started
+    url: https://github.com/oxyroid/M3UAndroid#readme
+    about: Read setup notes, download links, and common project information before opening an issue.
+  - name: Latest GitHub Release
+    url: https://github.com/oxyroid/M3UAndroid/releases/latest
+    about: Download the latest stable release and check release notes before reporting a bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,38 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: '[Feature] '
+labels: enhancement
 assignees: ''
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
+
+**User scenario**
+Describe who would use this feature, what they are trying to do, and when they need it.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+A clear and concise description of any alternative solutions, workarounds, apps, or existing M3UAndroid flows you've considered.
+
+**Platform scope**
+- [ ] Smartphone
+- [ ] Android TV
+- [ ] Both Smartphone and Android TV
+- [ ] Not sure
+
+**Compatibility impact**
+Could this affect existing playlists, Xtream API providers, EPG data, playback behavior, DLNA, settings, import/export files, extensions, or Android TV focus behavior?
+
+- [ ] No known compatibility impact
+- [ ] Yes, describe below
+- [ ] Not sure
+
+Details:
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add any other context, mockups, screenshots, links, or examples about the feature request here.

--- a/.github/ISSUE_TEMPLATE/playback_issue.md
+++ b/.github/ISSUE_TEMPLATE/playback_issue.md
@@ -1,0 +1,81 @@
+---
+name: Playback issue
+about: Report stream playback, decoder, buffering, or Media3/ExoPlayer behavior
+title: '[Playback] '
+labels: bug, playback
+assignees: ''
+
+---
+
+**Check before feedback**
+- [ ] I checked existing issues to ensure this has not already been reported.
+- [ ] I reproduced the issue on the latest GitHub Release or Nightly build when possible.
+- [ ] I removed or masked private stream URLs, tokens, usernames, passwords, and server addresses.
+
+**App and device**
+- App variant:
+  - [ ] Smartphone
+  - [ ] TV
+- Installation source:
+  - [ ] GitHub Release
+  - [ ] Nightly
+  - [ ] Self-built
+- Version or commit: [e.g. 1.10.2 or commit SHA]
+- Device model: [e.g. Google Pixel 8, Chromecast with Google TV]
+- Android version: [e.g. Android 14]
+- Is this an Android TV device?
+  - [ ] Yes
+  - [ ] No
+  - [ ] Not sure
+
+**Stream details**
+- Stream URL type:
+  - [ ] HLS / .m3u8
+  - [ ] MPEG-TS / .ts
+  - [ ] DASH / .mpd
+  - [ ] MP4
+  - [ ] RTSP
+  - [ ] Other:
+- Video codec: [e.g. H.264/AVC, H.265/HEVC, AV1, MPEG-2, unknown]
+- Audio codec: [e.g. AAC, AC3, EAC3, MP2, unknown]
+- Resolution / frame rate if known: [e.g. 1920x1080 50fps]
+- DRM or special headers required?
+  - [ ] Yes
+  - [ ] No
+  - [ ] Not sure
+
+**External player comparison**
+- Does the same stream play in an external player?
+  - [ ] Yes, VLC
+  - [ ] Yes, another player:
+  - [ ] No
+  - [ ] Not tested
+- If it plays externally, note any differences in startup time, audio/video sync, subtitles, or buffering.
+
+**Network environment**
+- Connection type:
+  - [ ] Wi-Fi
+  - [ ] Ethernet
+  - [ ] Mobile data
+  - [ ] VPN / proxy
+- Network notes: [ISP, region, VPN, LAN/NAS, provider rate limits, etc.]
+
+**Media3 / ExoPlayer behavior**
+- What happens in M3UAndroid?
+  - [ ] Never starts
+  - [ ] Buffers repeatedly
+  - [ ] Audio only
+  - [ ] Video only
+  - [ ] Audio/video out of sync
+  - [ ] Decoder error
+  - [ ] App crash
+  - [ ] Other:
+- Error message or player error if shown:
+
+**Reproduction steps**
+1. Open '...'
+2. Play channel or stream '...'
+3. Observe '...'
+
+**Sanitized sample and logs**
+Attach a sanitized sample playlist entry, stream metadata, Logcat output, screenshot, or screen recording if possible.

--- a/.github/ISSUE_TEMPLATE/tv_focus_issue.md
+++ b/.github/ISSUE_TEMPLATE/tv_focus_issue.md
@@ -1,0 +1,50 @@
+---
+name: TV focus issue
+about: Report Android TV remote, DPad navigation, initial focus, or back/confirm behavior
+title: '[TV Focus] '
+labels: bug, tv
+assignees: ''
+
+---
+
+**Check before feedback**
+- [ ] I checked existing issues to ensure this has not already been reported.
+- [ ] I reproduced the issue on the latest GitHub Release or Nightly build when possible.
+
+**TV environment**
+- Installation source:
+  - [ ] GitHub Release
+  - [ ] Nightly
+  - [ ] Self-built
+- Version or commit: [e.g. 1.10.2 or commit SHA]
+- Device model: [e.g. Chromecast with Google TV, NVIDIA Shield TV]
+- Android TV version: [e.g. Android TV 12]
+- Remote/controller model if relevant: [e.g. OEM remote, Bluetooth keyboard, gamepad]
+
+**Affected screen or flow**
+- Screen name: [e.g. playlist list, channel grid, player overlay, settings]
+- Entry path to the screen: [e.g. Home > Playlist > Channel]
+
+**Remote / DPad path**
+List the exact remote buttons pressed before the issue appears:
+
+1. Press '...'
+2. Press '...'
+3. Focus moves to / gets stuck at '...'
+
+**Initial focus**
+- What item has focus when the screen opens?
+- What item should have focus instead?
+
+**Back / confirm behavior**
+- Where does OK / confirm fail or activate the wrong item?
+- Where does Back fail, close the wrong layer, or exit unexpectedly?
+
+**Expected behavior**
+Describe the focus movement, confirmation, or back behavior you expected.
+
+**Screenshot or recording**
+Attach a screenshot or screen recording showing the current focus highlight, missing focus state, or stuck navigation path.
+
+**Additional context**
+Add any other TV-specific context, such as overscan, accessibility settings, screen density, or display scaling.


### PR DESCRIPTION
### Motivation
- Reduce empty/low-quality issues by disabling blank issues and giving links to Telegram, README, and latest release. 
- Improve bug triage by collecting variant, install source, device/Android details, problem category, playlist context, and sanitized logs. 
- Provide specialized forms for playback and Android TV focus problems to gather protocol/codec, ExoPlayer behavior, network, and DPad path details. 
- Improve feature requests with user scenarios, alternatives, platform scope, and compatibility impact to evaluate change risk.

### Description
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and surface contact links (Telegram, README, latest release). 
- Update `bug_report.md` to include app variant, installation source, app version/commit, device and Android environment, problem type checklist, playlist/provider context, and clearer log/screenshot guidance. 
- Add `playback_issue.md` to collect stream URL type, codecs, external player comparison, network environment, Media3/ExoPlayer symptoms, reproduction steps, and sanitized logs. 
- Add `tv_focus_issue.md` to collect TV device info, affected screen/entry path, exact remote/DPad button path, initial-focus expectations, back/confirm problems, and screenshot/recording attachments. 
- Extend `feature_request.md` with user scenario, alternatives/workarounds, platform scope, and explicit compatibility-impact fields, and remove trailing whitespace from templates.

### Testing
- Ran `git diff --check` which initially reported trailing whitespace issues in the edited templates. 
- Fixed whitespace with `perl -pi -e 's/[ \t]+$//' .github/ISSUE_TEMPLATE/*.md .github/ISSUE_TEMPLATE/config.yml` and re-ran `git diff --check`, which passed with no remaining check failures. 
- Verified the new and updated template files are present with `nl -ba .github/ISSUE_TEMPLATE/*`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5de635d5bc832887e5fc20dbc2deb3)